### PR TITLE
Adds error handing

### DIFF
--- a/lib/Connector.js
+++ b/lib/Connector.js
@@ -95,8 +95,8 @@ var Connector = {
 //console.log(request_options);return;
 
 		request(request_options, function(error, response, body) {
+			var result = JSON.parse(body);
 			if (!error && response.statusCode == 200) {
-				var result = JSON.parse(body);
 				if (typeof result.result_code != "undefined") {
 					result.success = result.result_code;
 					if (!result.result_code) {
@@ -112,7 +112,7 @@ var Connector = {
 				return cb(result);
 			}
 			else {
-				console.log("Error: " + response.statusCode);
+				console.log(result);
 			}
 		});
 


### PR DESCRIPTION
Fixes the issue where calling a contact that doesn’t exist does not
return anything.

Now returns result code according to [this blog post](http://www.activecampaign.com/blog/detecting-api-errors/) on detecting API errors
