### PR TITLE
Fixed missing instance in instance method call

### DIFF
--- a/lib/Connector.js
+++ b/lib/Connector.js
@@ -22,7 +22,7 @@ var Connector = {
 		regex = new RegExp("\/$");
 		if (url.match(regex)) {
 			// remove trailing slash
-			url = replace(regex, "");
+			url = url.replace(regex, "");
 		}
 		if (api_key) {
 			this.url = url + base + "/api.php?api_key=" + api_key;


### PR DESCRIPTION
The missing url instance object was dealing ReferenceError:

    .../node_modules/activecampaign/lib/Connector.js:25
			url = replace(regex, "");
			      ^
    ReferenceError: replace is not defined
