### PR TITLE
Pass actid, key and email via POST data

### DIFF
--- a/lib/Tracking.js
+++ b/lib/Tracking.js
@@ -57,14 +57,14 @@ var AC_Tracking = {
 
 	log: function(Connector, params, post_data) {
 		Connector.url = "https://trackcmp.net/event";
-		post_data.actid = this.track_actid;
-		post_data.key = this.track_key;
+		post_data.actid = post_data.track_actid;
+		post_data.key = post_data.track_key;
 		var visit_data = {};
-		if (this.track_email) {
-			visit_data.email = this.track_email;
+		if (post_data.track_email) {
+			visit_data.email = post_data.track_email;
 		}
 		if (typeof(post_data.visit) != "undefined") {
-			
+
 		}
 		if (Object.keys(visit_data).length) {
 			post_data.visit = visit_data;


### PR DESCRIPTION
I wasn't able to pass in the actid, key and email. Couldn't find it in the documentation.

```
var eventdata = {
            track_actid: "xxxxxxx",
            track_key: "xxxxxxxxxxxxxxxxxxxx",
            track_email: email,
            "event": "eventname",
            "eventdata": "eventdata"
};
var log_event = ac.api("tracking/log", eventdata);
log_event.then(function (result) {
            // successful request
            console.log(result);
        }, function (result) {
            // request error
 });
```