### PR TITLE
Added contact tag methods to whitelist

### DIFF
--- a/lib/Contact.js
+++ b/lib/Contact.js
@@ -3,7 +3,7 @@ var AC_Contact = {
 	version: 1,
 	url_base: "",
 
-	whitelist: ["add", "delete_list", "delete", "edit", "list", "paginator", "sync", "view"],
+	whitelist: ["add", "delete_list", "delete", "edit", "list", "paginator", "sync", "view", "tag_add", "tag_remove"],
 	
 	view: function(Connector, params, post_data) {
 		var action = "contact_view";


### PR DESCRIPTION
This allows API users to make calls like:

	var data = {email: 'test@test.com', tags: 'tag1,tag2,etc'};
	ac.api('contact/tag/add', data);

Noticed this issue from #10 