### PR TITLE
Single sign-on fix [#100941148]

### DIFF
--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -3,8 +3,14 @@ var AC_Auth = {
 	version: 1,
 	url_base: "",
 
-	whitelist: ["singlesignon"]
-		
+	whitelist: ["singlesignon"],
+
+	singlesignon: function(Connector, params, post_data) {
+		var action = "singlesignon";
+		Connector.action = action;
+		return Connector;
+	}
+
 };
 
 module.exports = AC_Auth;


### PR DESCRIPTION
Need to reset the "action" to just `singlesignon` instead of `auth_singlesignon`, otherwise you get a "You are not authorized to access this file" error returned.

Example request: `ac.api('auth/singlesignon?sso_addr=&sso_user=&sso_duration=', {})`.