### PR TITLE
Fix syntax highlighting on example code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If you don't use NPM, try this:
 
 ## Example Usage
 
+```javascript
 	var ActiveCampaign = require("activecampaign");
 
 	var ac = new ActiveCampaign("https://ACCOUNT.api-us1.com", {{KEY}});
@@ -70,6 +71,7 @@ If you don't use NPM, try this:
 	}, function(result) {
 		// request error
 	});
+```
 
 ## Full Documentation
 


### PR DESCRIPTION
The example code block isn't highlighted right now. This change will force JS highlighting.