### PR TITLE
Node.js wrapper update for segment_list [#114038301]

### DIFF
--- a/lib/Connector.js
+++ b/lib/Connector.js
@@ -58,6 +58,38 @@ var Connector = {
 		var request_url = Connector.prepare_url(Connector.action, params);
 		return Connector.curl(request_url, post_data);
 	},
+
+	/**
+	 * Parses an object and makes it into a URL query string for use with the API request.
+	 *
+	 * @param  array  params  The object of URL data in key=value format. Example: {"one":1, "two":2, "three": {"three1":31}}
+	 * @return string         The encoded URL query string.
+	 */
+	http_build_query: function(params) {
+		var params_str = "";
+		for (var i in params) {
+			if (typeof(params[i]) == "object") {
+				var counter = 1;
+				for (var j in params[i]) {
+					var obj_length = Object.keys(params[i]).length;
+					params_str += i + encodeURIComponent("[" + j + "]") + "=" + encodeURIComponent(params[i][j]);
+					if (counter < obj_length) {
+						params_str += "&";
+					}
+					counter++;
+				}
+			} else {
+				var counter = 1;
+				var obj_length = Object.keys(params).length;
+				params_str += i + "=" + encodeURIComponent(params[i]);
+				if (counter < obj_length) {
+					params_str += "&";
+				}
+				counter++;
+			}
+		}
+		return params_str;
+	},
 	
 	curl: function(url, post_data) {
 		if (this.version == 1) {

--- a/lib/Connector.js
+++ b/lib/Connector.js
@@ -46,7 +46,11 @@ var Connector = {
 			request_url = Connector.url + "&api_action=" + action + "&api_output=" + Connector.output;
 		}
 		if (params) {
-			request_url += "&" + params;
+			var separator = "?";
+			if (request_url.match(/\?/)) {
+				separator = "&";
+			}
+			request_url += separator + params;
 		}
 		if (this.debug) {
 			console.log("API request URL: " + request_url);
@@ -69,28 +73,22 @@ var Connector = {
 		var params_str = "";
 		for (var i in params) {
 			if (typeof(params[i]) == "object") {
-				var counter = 1;
 				for (var j in params[i]) {
 					var obj_length = Object.keys(params[i]).length;
 					params_str += i + encodeURIComponent("[" + j + "]") + "=" + encodeURIComponent(params[i][j]);
-					if (counter < obj_length) {
-						params_str += "&";
-					}
-					counter++;
-				}
-			} else {
-				var counter = 1;
-				var obj_length = Object.keys(params).length;
-				params_str += i + "=" + encodeURIComponent(params[i]);
-				if (counter < obj_length) {
 					params_str += "&";
 				}
-				counter++;
+			} else {
+				var obj_length = Object.keys(params).length;
+				params_str += i + "=" + encodeURIComponent(params[i]);
+				params_str += "&";
 			}
 		}
+		// Trim off trailing "&" character.
+		params_str = params_str.substring(0, params_str.length - 1);
 		return params_str;
 	},
-	
+
 	curl: function(url, post_data) {
 		if (this.version == 1) {
 			// find the method from the URL
@@ -103,7 +101,11 @@ var Connector = {
 				method = matches[0];
 			}
 		} else if (this.version == 2) {
-			url += "?api_key=" + this.api_key;
+			var separator = "?";
+			if (url.match(/\?/)) {
+				separator = "&";
+			}
+			url += separator + "api_key=" + this.api_key;
 		}
 
 		body = "";

--- a/lib/Segment.js
+++ b/lib/Segment.js
@@ -1,0 +1,15 @@
+var AC_Segment = {
+
+	version: 1,
+	url_base: "",
+
+	whitelist: ["list"],
+
+	list: function(Connector, params, post_data) {
+		// version 2 only.
+		Connector.url = this.url_base + "/segment/list";
+	}
+		
+};
+
+module.exports = AC_Segment;

--- a/lib/Segment.js
+++ b/lib/Segment.js
@@ -1,3 +1,37 @@
+/**
+ * Code example:
+
+	var ActiveCampaign = require("activecampaign");
+	var Connector = require(__dirname + "/node_modules/activecampaign/lib/Connector");
+
+	var ac = new ActiveCampaign("{URL}", "{KEY}");
+	ac.debug = true;
+	ac.version(2);
+
+	var params = {
+		"filters": {
+			"name": "",
+			"list_id": 1,
+			"automation_id": 12	
+		},
+		"sort": "id",
+		"sort_direction": "ASC",
+		"page": 1
+	}
+
+	params = Connector.http_build_query(params);
+	var segments = ac.api("segment/list?" + params, {});
+
+	segments.then(function(result) {
+		// successful request
+		console.log(result);
+	}, function(result) {
+		// request error
+	});
+
+ *
+ */
+
 var AC_Segment = {
 
 	version: 1,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "activecampaign",
   "description": "Node.js wrapper for the ActiveCampaign API",
   "author": "ActiveCampaign <help@activecampaign.com>",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ActiveCampaign/activecampaign-api-nodejs.git"


### PR DESCRIPTION
Allows access to this new API method using the wrapper. Example:

`ac.api("segment/list?params", {});`

I also need git tag `1.2.0` created in the upstream repo (for NPM versioning) as this was a minor release (new feature but should not break previous functionality).