### PR TITLE
Patch version increment (1.2.1) [#121159131]

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "activecampaign",
   "description": "Node.js wrapper for the ActiveCampaign API",
   "author": "ActiveCampaign <help@activecampaign.com>",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ActiveCampaign/activecampaign-api-nodejs.git"


### PR DESCRIPTION
This is for the recent fixes for invalid JSON output (such as if it's an invalid API key - our server returns HTML).