### PR TITLE
Reset the request method before every call

### DIFF
--- a/lib/Connector.js
+++ b/lib/Connector.js
@@ -90,6 +90,7 @@ var Connector = {
 	},
 
 	curl: function(url, post_data) {
+		this.request_method = "GET";
 		if (this.version == 1) {
 			// find the method from the URL
 			var regex = new RegExp("api_action=[^&]*");


### PR DESCRIPTION
If you perform a POST and GET subsequent the GET will fail because it is send as POST call. This is because the request_method is never reset to GET.