### PR TITLE
add view_email to whitelist

### DIFF
--- a/lib/Contact.js
+++ b/lib/Contact.js
@@ -3,7 +3,7 @@ var AC_Contact = {
 	version: 1,
 	url_base: "",
 
-	whitelist: ["add", "delete_list", "delete", "edit", "list", "paginator", "sync", "view", "tag_add", "tag_remove"],
+	whitelist: ["add", "delete_list", "delete", "edit", "list", "paginator", "sync", "view", "view_email", "tag_add", "tag_remove"],
 	
 	view: function(Connector, params, post_data) {
 		var action = "contact_view";


### PR DESCRIPTION
Add the contact_view_email API to the white list so that the URL string "contact/view/email" is accepted.
