### PR TITLE
Fix for event tracking URL overwriting v1 API URL DEVJIRA-8782

### DIFF
--- a/lib/Connector.js
+++ b/lib/Connector.js
@@ -6,6 +6,7 @@ var Connector = {
 
 	version: 1,
 	url: "",
+	url_tracking: "https://trackcmp.net/event",
 	api_key: "",
 	output: "json",
 	debug: false,
@@ -41,6 +42,9 @@ var Connector = {
 	
 	prepare_url: function(action, params) {
 		var request_url = Connector.url;
+		if (action == "tracking_log") {
+			request_url = this.url_tracking;
+		}
 		// tracking_log is a completely different URL.
 		if (this.version == 1 && action != "tracking_log") {
 			request_url = Connector.url + "&api_action=" + action + "&api_output=" + Connector.output;

--- a/lib/Tracking.js
+++ b/lib/Tracking.js
@@ -56,7 +56,6 @@ var AC_Tracking = {
 	},
 
 	log: function(Connector, params, post_data) {
-		Connector.url = "https://trackcmp.net/event";
 		post_data.actid = this.track_actid;
 		post_data.key = this.track_key;
 		var visit_data = {};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "activecampaign",
   "description": "Node.js wrapper for the ActiveCampaign API",
   "author": "ActiveCampaign <help@activecampaign.com>",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/ActiveCampaign/activecampaign-api-nodejs.git"


### PR DESCRIPTION
This issue was evident when running an event tracking API request, then running a version 1 API request. The error for the v1 request would be: 'An account ID must be provided.' It was still holding on to the tracking URL as the main URL.

This change stops overwriting the main URL and instead uses the tracking URL only when needed.

@ActiveCampaign/integration Please review, thanks!
