### PR TITLE
add note_add to contact whitelist

### DIFF
--- a/lib/Contact.js
+++ b/lib/Contact.js
@@ -3,7 +3,7 @@ var AC_Contact = {
 	version: 1,
 	url_base: "",
 
-	whitelist: ["add", "delete_list", "delete", "edit", "list", "paginator", "sync", "view", "tag_add", "tag_remove"],
+	whitelist: ["add", "delete_list", "delete", "edit", "list", "paginator", "sync", "view", "tag_add", "tag_remove", "note_add"],
 	
 	view: function(Connector, params, post_data) {
 		var action = "contact_view";


### PR DESCRIPTION
added "note_add" to the whitelist of contact. This action was missing from the list.
